### PR TITLE
Add parameter for setup timeout, setting at parallel default (120 secs)

### DIFF
--- a/R/CMDist.R
+++ b/R/CMDist.R
@@ -6,7 +6,7 @@
 #' @examples cm.dists <- CMDist(dtm, cw = "death", wv = wordvectors, scale = TRUE)
 #' @export
 #' 
-  CMDist <- function(dtm, cw = NULL, cv = NULL, wv, method = "cosine", scale = TRUE, parallel = FALSE, threads = 2) {
+  CMDist <- function(dtm, cw = NULL, cv = NULL, wv, method = "cosine", scale = TRUE, parallel = FALSE, threads = 2, setup_timeout = 120) {
             
             list_output <- .prepINPUT(dtm, cw, cv, wv)
 
@@ -29,7 +29,7 @@
               require("doSNOW")
               # Determine chunk-size to be processed by different threads
               ind <- bigstatsr:::CutBySize(nrow(dtm), nb = threads)
-              cl  <- parallel::makeCluster(threads)
+              cl  <- parallel::makeCluster(threads, setup_timeout = setup_timeout)
               doSNOW::registerDoSNOW(cl)
               dist <- .parDist2(dtm, pdtm, wem, ind, method)
               on.exit(parallel::stopCluster(cl))


### PR DESCRIPTION
Resolves #2 

I added a new parameter to `CMDist()`. `setup_timeout` defaults to 120 seconds, which is the default in {parallel}. This should not impact performance on other systems, but the link below indicates that setting the new parameter below 1 second resolves that problem. I have successfully been able to parallelize `CMDist()` with `setup_timeout = .5`.

https://github.com/rstudio/rstudio/issues/6692
